### PR TITLE
Remove unnecessary route requests

### DIFF
--- a/WME Route Speeds (MapOMatic fork).js
+++ b/WME Route Speeds (MapOMatic fork).js
@@ -1816,7 +1816,7 @@
 		else {
 			getId('sidepanel-routespeeds').style.color = "";
 
-			if (showMarkers(true)) livemapRoute();
+			if (showMarkers(true)) rezoom();
 			showClosures(1);
 		}
 	}

--- a/WME Route Speeds (MapOMatic fork).js
+++ b/WME Route Speeds (MapOMatic fork).js
@@ -10,8 +10,6 @@
 // @copyright           2014, 2015 wlodek76
 // @contributor         2014, 2015 FZ69617
 // @connect             greasyfork.org
-// @downloadURL https://update.greasyfork.org/scripts/369630/WME%20Route%20Speeds%20%28MapOMatic%20fork%29.user.js
-// @updateURL https://update.greasyfork.org/scripts/369630/WME%20Route%20Speeds%20%28MapOMatic%20fork%29.meta.js
 // ==/UserScript==
 
 /* global W */

--- a/WME Route Speeds (MapOMatic fork).js
+++ b/WME Route Speeds (MapOMatic fork).js
@@ -10,6 +10,8 @@
 // @copyright           2014, 2015 wlodek76
 // @contributor         2014, 2015 FZ69617
 // @connect             greasyfork.org
+// @downloadURL https://update.greasyfork.org/scripts/369630/WME%20Route%20Speeds%20%28MapOMatic%20fork%29.user.js
+// @updateURL https://update.greasyfork.org/scripts/369630/WME%20Route%20Speeds%20%28MapOMatic%20fork%29.meta.js
 // ==/UserScript==
 
 /* global W */
@@ -1823,17 +1825,17 @@
 	//--------------------------------------------------------------------------------------------------------
 	function clickOption2() {
 		routespeedsoption2 = (getId('routespeeds-option2').checked === true);
-		livemapRoute();
+		rezoom();
 	}
 	//--------------------------------------------------------------------------------------------------------
 	function clickOption3() {
 		routespeedsoption3 = (getId('routespeeds-option3').checked === true);
-		livemapRoute();
+		rezoom();
 	}
 	//--------------------------------------------------------------------------------------------------------
 	function clickOption4() {
 		routespeedsoption4 = (getId('routespeeds-option4').checked === true);
-		livemapRoute();
+		rezoom();
 	}
 	//--------------------------------------------------------------------------------------------------------
 	function clickOption5() {


### PR DESCRIPTION
Toggling the "Disable script", "Hide labels", "Show cross-times through segments", and "Speed in mph" options now simply redraws the routes with the new options rather than requesting them again.