### PR TITLE
Fix tab label element selector

### DIFF
--- a/WME Route Speeds (MapOMatic fork).js
+++ b/WME Route Speeds (MapOMatic fork).js
@@ -673,7 +673,7 @@
 
         if (!options.enableScript) return;
 
-        var tabOpen = $('#routespeeds-tab-label').parent().parent().attr('aria-expanded') == "true";
+        var tabOpen = $('#user-tabs #routespeeds-tab-label').parent().parent().attr('aria-expanded') == "true";
         if (!tabOpen) {
             if (tabswitched !== 1) {
                 tabswitched = 1;


### PR DESCRIPTION
Another element with ID routespeeds-tab-label seems to be present in the DOM, which gets matched first. By including the user-tabs ID, we're certain to match the element we want. Everything else seems to work as intended, although the route server fails to process requests from time to time.